### PR TITLE
Adds CRUD operations for DetalleVenta in the API

### DIFF
--- a/API-Venta/API-Venta/src/main/java/com/example/API_Venta/controllers/DetalleVentaController.java
+++ b/API-Venta/API-Venta/src/main/java/com/example/API_Venta/controllers/DetalleVentaController.java
@@ -1,8 +1,49 @@
 package com.example.API_Venta.controllers;
 
+import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+import com.example.API_Venta.dto.DetalleVentaDTO;
+import com.example.API_Venta.services.DetalleVentaService;
 
+@RestController
+@RequestMapping("/api/detalleventa")
 public class DetalleVentaController {
 
+    @Autowired
+    private DetalleVentaService detalleVentaService;
+
+    @GetMapping
+    public List<DetalleVentaDTO> listarTodos() {
+        return detalleVentaService.listarTodos();
+    }
+
+    @PostMapping
+    public DetalleVentaDTO crearDetalleVenta(@RequestBody DetalleVentaDTO detalleVentaDTO) {
+        return detalleVentaService.crear(detalleVentaDTO);
+    }
+
+    @GetMapping("/{id}")
+    public DetalleVentaDTO obtenerPorId(@PathVariable Integer id) {
+        return detalleVentaService.obtenerPorId(id);
+    }
+
+    @PutMapping("/{id}")
+    public DetalleVentaDTO actualizarDetalleVenta(@PathVariable Integer id, @RequestBody DetalleVentaDTO detalleVentaDTO) {
+        return detalleVentaService.actualizar(id, detalleVentaDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public void eliminarDetalleVenta(@PathVariable Integer id) {
+        detalleVentaService.eliminar(id);
+    }
 }

--- a/API-Venta/API-Venta/src/main/java/com/example/API_Venta/dto/DetalleVentaDTO.java
+++ b/API-Venta/API-Venta/src/main/java/com/example/API_Venta/dto/DetalleVentaDTO.java
@@ -1,5 +1,7 @@
 package com.example.API_Venta.dto;
 
+
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/API-Venta/API-Venta/src/main/java/com/example/API_Venta/models/DetalleVenta.java
+++ b/API-Venta/API-Venta/src/main/java/com/example/API_Venta/models/DetalleVenta.java
@@ -1,8 +1,6 @@
 package com.example.API_Venta.models;
 
 
-
-
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/API-Venta/API-Venta/src/main/java/com/example/API_Venta/repository/DetalleVentaRepository.java
+++ b/API-Venta/API-Venta/src/main/java/com/example/API_Venta/repository/DetalleVentaRepository.java
@@ -1,5 +1,6 @@
 package com.example.API_Venta.repository;
 
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/API-Venta/API-Venta/src/main/java/com/example/API_Venta/services/DetalleVentaService.java
+++ b/API-Venta/API-Venta/src/main/java/com/example/API_Venta/services/DetalleVentaService.java
@@ -2,6 +2,9 @@ package com.example.API_Venta.services;
 
 
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -61,4 +64,18 @@ public class DetalleVentaService {
     public void eliminar(Integer id) {      // Elimina un DetalleVenta por su ID
         detallerepository.deleteById(id);
     }
+
+    public List<DetalleVentaDTO> listarTodos() {    // Devuelve todos los DetalleVenta como lista de DTO
+        List<DetalleVenta> detalles = detallerepository.findAll();
+        return detalles.stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public DetalleVentaDTO obtenerPorId(Integer id) {   // Devuelve un DetalleVentaDTO por su ID
+        DetalleVenta detalle = detallerepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("DetalleVenta no encontrado"));
+        return toDTO(detalle);
+    }
 }
+


### PR DESCRIPTION
Implements the complete set of CRUD operations for the DetalleVenta entity within the API, enhancing functionality for managing sales details.

Introduces a new controller with endpoints for listing, creating, retrieving, updating, and deleting DetalleVenta records.

Updates the service layer to support these operations, ensuring improved data handling and service integration.

No specific issues were referenced in the changes.